### PR TITLE
Rewrite the 'convert' command

### DIFF
--- a/src/commands/convert.js
+++ b/src/commands/convert.js
@@ -1,91 +1,133 @@
-// TODO: This whole thing is terrible, this is the only command that wasn't rewritten when I made the Satania rewrite
+/**
+ * A length unit used for unit convertion
+ * @typedef {Object} LengthUnit
+ * @property {string} symbol The symbol of a unit
+ * @property {Array<string>} names User-friendly names of the unit
+ * @property {number} multiplier The multiplier relative to the base unit (which
+ *  has this property set to 1)
+ */
+const imperialUnits = [
+	{
+		symbol: 'in',
+		names: ['inch', 'inches', '"'],
+		multiplier: 1
+	},
+	{
+		symbol: 'ft',
+		names: ['foot', 'feet', '\''],
+		multiplier: 12
+	},
+	{
+		symbol: 'yd',
+		names: ['yard', 'yards'],
+		multiplier: 12 * 3
+	},
+	{
+		symbol: 'ch',
+		names: ['chain', 'chains'],
+		multiplier: 12 * 3 * 22
+	},
+	{
+		symbol: 'fur',
+		names: ['furlong', 'furlongs'],
+		multiplier: 12 * 3 * 22 * 10
+	},
+	{
+		symbol: 'ml',
+		names: ['mile', 'miles'],
+		multiplier: 12 * 3 * 22 * 10 * 8
+	}
+];
 
-function parseConvertionInput(input) {
-	let units = {
-		type: undefined
-	};
-	const unitRegex = /(-?[\d,.]+)(?:\s?([^\d\s]+))?/g;
+const metricUnits = [
+	{
+		symbol: 'mm',
+		names: ['millimeter', 'millimeters'],
+		multiplier: 0.001
+	},
+	{
+		symbol: 'cm',
+		names: ['centimeter', 'centimeters'],
+		multiplier: 0.01
+	},
+	{
+		symbol: 'dm',
+		names: ['decimeter', 'decimeters'],
+		multiplier: 0.1
+	},
+	{
+		symbol: 'm',
+		names: ['meter', 'meters'],
+		multiplier: 1
+	},
+	{
+		symbol: 'dam',
+		names: ['decameter', 'decameters'],
+		multiplier: 10
+	},
+	{
+		symbol: 'hm',
+		names: ['hectometer', 'hectometers'],
+		multiplier: 100
+	},
+	{
+		symbol: 'km',
+		names: ['kilometer', 'kilometers'],
+		multiplier: 1000
+	}
+];
 
-	const imperialUnits = [
-		'inch', 'inches', 'in', '"',
-		'foot', 'feet', 'ft', '\'',
-		'yard', 'yards', 'yd',
-		'chain', 'chains', 'ch',
-		'furlong', 'furlongs', 'fur',
-		'mile', 'miles', 'ml'
-	];
+/**
+ * Convert a user-friendly name of a unit to the unit's symbol, eg.
+ * "meters" -> "m", "meter" -> "m", "m" -> "m"
+ * @param {Array<LengthUnit>} units An array of units to look up
+ * @param {string} text A string to be matched
+ * @returns {?Array} An array containing all results of RegExp#exec or null
+ */
+function getUnitSymbol(units, unitName) {
+	const matchingUnits = units
+		.filter(unit => unit.symbol === unitName || unit.names.includes(unitName));
 
-	const metricUnits = [
-		'millimeters', 'millimeter', 'mm',
-		'centimeters', 'centimeter', 'cm',
-		'decimeters', 'decimeter', 'dm',
-		'meters', 'meter', 'm',
-		'decameters', 'decameter', 'dam',
-		'hectometers', 'hectometer', 'hm',
-		'kilometers', 'kilometer', 'km'
-	];
+	return matchingUnits.length > 0 ? matchingUnits[0].symbol : null;
+}
 
+/**
+ * Execute a regular expression and return all matching values (a RegExp with
+ * the global flag can match multiple values in a single string)
+ * @param {RegExp} regexp A RegExp to match the string against
+ * @param {string} text A string to be matched
+ * @returns {Array} An array containing all results of RegExp#exec
+ */
+function getAllMatches(regexp, text) {
+	const results = [];
 	let value;
 
-	while ((value = unitRegex.exec(input)) !== null) {
-		value[1] = parseFloat(value[1].replace(/,/g, '.'), 10);
-
-		if (value[2] && imperialUnits.indexOf(value[2].toLowerCase()) >= 0) {
-			// IMPERIAL UNITS
-
-			if (typeof units.type === 'undefined') {
-				units = {
-					type: 'imperial',
-					inches: 0
-				};
-			}
-
-			if (['inch', 'inches', 'in', '"'].indexOf(value[2].toLowerCase()) >= 0) {
-				units.inches += value[1];
-			} else if (['foot', 'feet', 'ft', '\''].indexOf(value[2].toLowerCase()) >= 0) {
-				units.inches += value[1] * 12;
-			} else if (['yard', 'yards', 'yd'].indexOf(value[2].toLowerCase()) >= 0) {
-				units.inches += value[1] * 12 * 3;
-			} else if (['chain', 'chains', 'ch'].indexOf(value[2].toLowerCase()) >= 0) {
-				units.inches += value[1] * 12 * 3 * 22;
-			} else if (['furlong', 'furlongs', 'fur'].indexOf(value[2].toLowerCase()) >= 0) {
-				units.inches += value[1] * 12 * 3 * 22 * 10;
-			} else if (['mile', 'miles', 'ml'].indexOf(value[2].toLowerCase()) >= 0) {
-				units.inches += value[1] * 12 * 3 * 22 * 10 * 8;
-			}
-		} else if (value[2] && metricUnits.indexOf(value[2].toLowerCase()) >= 0) {
-			// METRIC UNITS
-
-			if (typeof units.type === 'undefined') {
-				units = {
-					type: 'metric',
-					meters: 0
-				};
-			}
-
-			if (/^(millimeters?|mm)$/i.test(value[2])) {
-				units.meters += value[1] * 0.001;
-			} else if (/^(centimeters?|cm)$/i.test(value[2])) {
-				units.meters += value[1] * 0.01;
-			} else if (/^(decimeters?|dm)$/i.test(value[2])) {
-				units.meters += value[1] * 0.1;
-			} else if (/^(meters?|m)$/i.test(value[2])) {
-				units.meters += Number(value[1]);
-			} else if (/^(decameters?|dam)$/i.test(value[2])) {
-				units.meters += value[1] * 10;
-			} else if (/^(hectometers?|hm)$/i.test(value[2])) {
-				units.meters += value[1] * 100;
-			} else if (/^(kilometers?|km)$/i.test(value[2])) {
-				units.meters += value[1] * 1000;
-			}
-		} else {
-			return {
-				type: 'error'
-			};
-		}
+	while ((value = regexp.exec(text)) !== null) {
+		results.push(value);
 	}
 
-	return units;
+	return results;
+}
+
+/**
+ * Parse user input containing length units and return them in a normalized
+ * format of an array of [number, unit symbol]
+ * @param {string} text User input
+ * @param {Array<Array<LengthUnit>>} unitSystems All supported unit systems
+ * @returns {Array<Array<number, string>>} An array of recognized units and values
+ */
+function parseUnits(text, unitSystems) {
+	const allUnits = unitSystems.reduce((units, system) => [...units, ...system]);
+	const parts = getAllMatches(/(-?[\d,.]+)(?:\s?([^\d\s]+))?/g, text)
+		.map(match => match.slice(1, 3))
+		.map(part => ({
+			value: parseFloat(/^[\d]+,[\d]+$/.test(part[0]) ?
+				part[0].replace(',', '.') :
+				part[0].replace(/,/g, ''), 10),
+			symbol: getUnitSymbol(allUnits, part[1])
+		}));
+
+	return parts;
 }
 
 const {Command} = require('discord-akairo');
@@ -96,51 +138,64 @@ const options = {
 		id: 'convert',
 		match: 'content'
 	}],
-	description: 'Very handy command to convert lengths from the metric system to imperial, and vice-versa!\n__**Examples:**__: `s!convert 1km`, `s!convert 6.5 miles`, `s!convert 6 meters`, `s!convert 5\'6"`'
+	description: 'Very handy command to convert lengths from the metric ' +
+		'system to imperial, and vice-versa!\n' +
+		'__**Examples:**__: `s!convert 1km`, `s!convert 6.5 miles`, ' +
+		'`s!convert 6 meters`, `s!convert 5\'6"`'
 };
 
 function exec(message, args) {
-	const units = parseConvertionInput(args.convert);
+	const unitSystems = [imperialUnits, metricUnits];
+	const input = parseUnits(args.convert, unitSystems);
+	const units = unitSystems
+		.filter(units =>
+			input.every(part => units.some(unit => unit.symbol === part.symbol))
+		)[0];
 
-	if (units.type === 'imperial') {
-		const meters = units.inches * 0.0254;
+	if (input.length === 0 || !units) {
+		// User's input is incomprehensible, give up
+		return message.reply('There was an error processing your mesurements.\n' +
+			'Maybe you typed something like `5\'4` or `1m50`, these ' +
+			'notations aren\'t supported, use `5\'4"` and `1.5m` instead.');
+	}
+
+	// The unit is inches for imperial and meters for metric
+	const sum = input
+		.map(part => {
+			const unit = units.filter(unit => unit.symbol === part.symbol)[0];
+			return part.value * unit.multiplier;
+		}).reduce((sum, number) => sum + number);
+
+	const inch = 0.0254;
+	let output;
+
+	if (units === imperialUnits) {
+		const meters = sum * inch;
 
 		if (meters >= 1000) {
-			return message.reply(`That would be ${Math.round(meters / 1000 * 100) / 100} kilometers!`);
+			output = `${Math.round(meters / 1000 * 100) / 100} kilometers`;
+		} else if (meters >= 1) {
+			output = `${Math.round(meters * 100) / 100} meters`;
+		} else if (meters >= 0.01) {
+			output = `${Math.round(meters * 100 * 100) / 100} centimeters`;
+		} else {
+			output = `${Math.round(meters * 1000 * 100000) / 100000} millimeters`;
 		}
-
-		if (meters >= 1) {
-			return message.reply(`That would be ${Math.round(meters * 100) / 100} meters!`);
-		}
-
-		if (meters >= 0.01) {
-			return message.reply(`That would be ${Math.round(meters * 100 * 100) / 100} centimeters!`);
-		}
-
-		return message.reply(`That would be ${Math.round(meters * 1000 * 100000) / 100000} millimeters!`);
-	}
-
-	if (units.type === 'metric') {
-		const inches = units.meters / 0.0254;
+	} else if (units === metricUnits) {
+		const inches = sum / inch;
 
 		if (inches >= 63360) {
-			return message.reply(`That would be ${Math.round(inches / 63360 * 100) / 100} miles!`);
+			output = `${Math.round(inches / 63360 * 100) / 100} miles`;
+		} else if (inches > 180) {
+			output = `${Math.round(inches / 12 * 100) / 100} feet`;
+		} else if (inches >= 12) {
+			output = `${Math.floor(inches / 12)}'${Math.floor(inches) % 12}"`;
+		} else {
+			output = `${Math.round(inches * 100000) / 100000} inches`;
 		}
-
-		if (inches > 180) {
-			return message.reply(`That would be ${Math.round(inches / 12 * 100) / 100} feet!`);
-		}
-
-		if (inches >= 12) {
-			return message.reply(`That would be ${Math.floor(inches / 12)}'${Math.floor(inches) % 12}"!`);
-		}
-
-		return message.reply(`That would be ${Math.round(inches * 100000) / 100000} inches!`);
 	}
 
-	if (units.type === 'error') {
-		return message.reply('There was an error processing your mesurements.\nMaybe you typed something like `5\'4` or `1m50` these notation aren\'t supported, use `5\'4"` and `1.5m` instead');
-	}
+	return message.reply(`That would be ${output}!`);
 }
 
 module.exports = new Command('convert', exec, options);


### PR DESCRIPTION
I rewrote the whole `convert.js` file for you since it had "TODO rewrite me ;_;". Everything should work the same (so eg. it still doesn't parse `s!convert 5'8`), the only changes, besides refactoring, are some typos in the "There was an error processing your mesurements" message and I also changed how commas in numbers are interpreted. Originally they were all just replaced with periods, now if there is a single comma and no period, it's still being replaced with a period (do eg. `42,1` works like `42.1`), but if there are multiple commas or a comma and a period, then commas will just be removed (so `1,000.00` is now `1000.00`).