### PR TITLE
Suppress the REPL's prompt while a command is running

### DIFF
--- a/src/repl.js
+++ b/src/repl.js
@@ -1,3 +1,11 @@
+const suppressPrompt = (replServer, defaultEval) => (...args) => {
+	const prompt = replServer._prompt;
+	replServer.setPrompt('');
+	defaultEval(...args);
+	replServer.setPrompt(prompt);
+	replServer.displayPrompt(true);
+};
+
 module.exports = client => {
 	const repl = require('repl');
 	const {Transform} = require('stream');
@@ -8,6 +16,7 @@ module.exports = client => {
 		useGlobal: true
 	});
 
+	replserver.eval = suppressPrompt(replserver, replserver.eval);
 	replserver.context.client = client;
 	replserver.context.replserver = replserver;
 


### PR DESCRIPTION
REPLStream's `_transform` function explicitly calls `replserver.displayPrompt` which causes a bug printing the REPL prompt before the value returned by a command, if that command happens to output something to the console. It looks like the value was typed by the user, while it really was just returned by the command they ran.

Node.js' behavior:
```js
> console.log('test')
test
undefined
>
```

SataniaBot's behavior:
```js
> console.log('test')
test
> undefined
>
```

This patch suppresses printing the prompt while the command invoked from the REPL is running. Basically it replaces the REPL's eval function with a function which first sets the prompt to an empty string, then runs the eval function the REPL would normally run, then sets the prompt back to whatever it was, so SataniaBot's REPL behaves the same as Node.js's REPL.